### PR TITLE
Add ESP-IDF v6 + fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "icm20948_dmp.c" "icm20948.c" "icm20948_i2c.c" "icm20948_spi.c"
     INCLUDE_DIRS "."
-    REQUIRES "driver"
+    REQUIRES driver esp_driver_spi esp_driver_i2c
 )

--- a/icm20948_i2c.c
+++ b/icm20948_i2c.c
@@ -1,28 +1,28 @@
-#include "driver/i2c.h"
+#include <string.h>
+#include "driver/i2c_master.h"
 
 #include "icm20948.h"
 #include "icm20948_i2c.h"
-
-#define ACK_CHECK_EN   0x1     /* I2C master will check ack from slave */
-#define ACK_CHECK_DIS  0x0     /* I2C master will not check ack from slave */
 
 
 icm20948_status_e icm20948_internal_write_i2c(uint8_t reg, uint8_t *data, uint32_t len, void *user)
 {
 	icm20948_status_e status = ICM_20948_STAT_OK;
 	icm0948_config_i2c_t *args = (icm0948_config_i2c_t*)user;
-	i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-	i2c_master_start(cmd);
-	i2c_master_write_byte(cmd, (args->i2c_addr << 1) | I2C_MASTER_WRITE, ACK_CHECK_EN);
-	i2c_master_write_byte(cmd, reg, true);
-	i2c_master_write(cmd, data, len, true);
-	i2c_master_stop(cmd);
-	
-	if(i2c_master_cmd_begin(args->i2c_port, cmd, 100 / portTICK_PERIOD_MS) != ESP_OK)
-	{
-		status = ICM_20948_STAT_ERR;
-	}
-	i2c_cmd_link_delete(cmd);
+    if (args == NULL || args->dev_handle == NULL) {
+        return ICM_20948_STAT_ERR;
+    }
+
+    uint8_t tx_buf[INV_MAX_SERIAL_WRITE + 1];
+    if (len > INV_MAX_SERIAL_WRITE) {
+        return ICM_20948_STAT_PARAM_ERR;
+    }
+    tx_buf[0] = reg;
+    memcpy(&tx_buf[1], data, len);
+    if (i2c_master_transmit(args->dev_handle, tx_buf, len + 1, 100) != ESP_OK)
+    {
+        status = ICM_20948_STAT_ERR;
+    }
     return status;
 }
 
@@ -30,20 +30,13 @@ icm20948_status_e icm20948_internal_read_i2c(uint8_t reg, uint8_t *buff, uint32_
 {
 	icm20948_status_e status = ICM_20948_STAT_OK;
 	icm0948_config_i2c_t *args = (icm0948_config_i2c_t*)user;
-    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
-	i2c_master_start(cmd);
-    i2c_master_write_byte(cmd, (args->i2c_addr << 1) | I2C_MASTER_WRITE, ACK_CHECK_EN);
-	i2c_master_write_byte(cmd, reg, true);
-	i2c_master_start(cmd);
-	i2c_master_write_byte(cmd, (args->i2c_addr << 1) | I2C_MASTER_READ, ACK_CHECK_EN);
-	i2c_master_read(cmd, buff, len, I2C_MASTER_LAST_NACK);
-	i2c_master_stop(cmd);
-	
-	if(i2c_master_cmd_begin(args->i2c_port, cmd, 100 / portTICK_PERIOD_MS) != ESP_OK)
-	{
-		status = ICM_20948_STAT_ERR;
-	}
-	i2c_cmd_link_delete(cmd);
+    if (args == NULL || args->dev_handle == NULL) {
+        return ICM_20948_STAT_ERR;
+    }
+    if (i2c_master_transmit_receive(args->dev_handle, &reg, 1, buff, len, 100) != ESP_OK)
+    {
+        status = ICM_20948_STAT_ERR;
+    }
     return status;
 }
 

--- a/icm20948_i2c.h
+++ b/icm20948_i2c.h
@@ -1,12 +1,14 @@
 #ifndef _ICM_20948_I2C_H_
 #define _ICM_20948_I2C_H_
 
-#include "driver/i2c.h"
+#include "driver/i2c_master.h"
 
 typedef struct
 {
-	i2c_port_t i2c_port;
-	uint8_t i2c_addr;
+ i2c_port_num_t i2c_port;
+ uint8_t i2c_addr;
+ i2c_master_bus_handle_t bus_handle;
+ i2c_master_dev_handle_t dev_handle;
 } icm0948_config_i2c_t;
 
 

--- a/icm20948_spi.c
+++ b/icm20948_spi.c
@@ -18,7 +18,7 @@ icm20948_status_e icm20948_internal_write_spi(uint8_t reg, uint8_t *data, uint32
         .tx_buffer = tx_buffer,
         .length = length*8
     };
-    if (spi_device_polling_transmit((spi_device_handle_t *)handle, &trans_desc) != ESP_OK)
+    if (spi_device_polling_transmit((spi_device_handle_t)handle, &trans_desc) != ESP_OK)
     {
         return ICM_20948_STAT_ERR;
     }
@@ -42,7 +42,7 @@ icm20948_status_e icm20948_internal_read_spi(uint8_t reg, uint8_t *buff, uint32_
 			.rx_buffer = rx_buffer,
             .length = length*8
     };
-    if (spi_device_polling_transmit((spi_device_handle_t *)handle, &trans_desc) != ESP_OK)
+    if (spi_device_polling_transmit((spi_device_handle_t)handle, &trans_desc) != ESP_OK)
     {
         return ICM_20948_STAT_ERR;
     }


### PR DESCRIPTION
This pull request updates the I2C and SPI communication layers for the ICM20948 sensor driver to use the latest ESP-IDF driver APIs, improves error handling, and updates the build configuration to require the correct dependencies. The main focus is on modernizing the I2C implementation to use the new `i2c_master` API, updating related data structures, and making minor corrections to SPI handling.

**I2C API modernization and improvements:**

* Updated `icm20948_i2c.c` to use the new `i2c_master` API, replacing the deprecated legacy I2C driver functions. This includes switching to `i2c_master_transmit` and `i2c_master_transmit_receive`, improving error checking, and simplifying buffer management.
* Modified the `icm0948_config_i2c_t` struct in `icm20948_i2c.h` to use new handle types (`i2c_port_num_t`, `i2c_master_bus_handle_t`, `i2c_master_dev_handle_t`) required by the updated API.

**Build configuration updates:**

* Updated `CMakeLists.txt` to require the `esp_driver_spi` and `esp_driver_i2c` components, ensuring all necessary dependencies are specified for the new API usage.

**SPI API correction:**

* Fixed the SPI transmit function calls in `icm20948_spi.c` by casting the handle to `spi_device_handle_t` instead of a pointer, aligning with the expected API usage. [[1]](diffhunk://#diff-927a53ebf0d9e51980fe54e2c927a901eedae234042e73d34fdc3696c928c3f0L21-R21) [[2]](diffhunk://#diff-927a53ebf0d9e51980fe54e2c927a901eedae234042e73d34fdc3696c928c3f0L45-R45)